### PR TITLE
add custom match block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,18 @@ that can/should be set via parameters to the role. Any variables that are read
 from other roles and/or the global scope (ie. hostvars, group vars, etc.)
 should be mentioned here as well.
 
+Add a custom match block like:
+
+.. code-block:: yaml
+
+   ssh_match_blocks:
+     - name: rootlogin
+       type: Address
+       path: '172.16.*'
+       options:
+         - name: PermitRootLogin
+           value: 'yes'
+
 
 Dependencies
 =============

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -133,3 +133,12 @@ Match Group sftp-only
     AllowTcpForwarding no
     X11Forwarding no
     #PermitTTY no
+{% if ssh_match_blocks | d() %}
+
+{% for block in ssh_match_blocks %}
+Match {{ block.type }} {{ block.path }}
+{% for option in block.options %}
+    {{ option.name }} {{ option.value }}
+{% endfor %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Allow adding custom match blockes (e.g.  User, Group, Host, LocalAddress, LocalPort, and Address) at the end of the config file.