### PR TITLE
SUSE Sle15 Support + Modernizations

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # Default is only rsa; ed25519 is recommended if supported by sshd.
 ssh_host_keys:
   - /etc/ssh/ssh_host_rsa_key
+  - /etc/ssh/ssh_host_ecdsa_key
   - /etc/ssh/ssh_host_ed25519_key
 
 # A list of all ports for sshd to listen on.

--- a/templates/etc/ssh/sshd_config.j2
+++ b/templates/etc/ssh/sshd_config.j2
@@ -17,8 +17,6 @@ Protocol 2
 {% for hostkey in ssh_host_keys %}
 HostKey {{ hostkey }}
 {% endfor %}
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 1h

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,0 +1,11 @@
+---
+
+ssh_packages:
+  - openssh
+
+ssh_service: sshd
+ssh_daemon_bin: /usr/sbin/sshd
+
+ssh_cfg: /etc/ssh/ssh_config
+ssh_daemon_cfg: /etc/ssh/sshd_config
+ssh_sftp_server: /usr/lib/openssh/sftp-server


### PR DESCRIPTION
##### SUMMARY
SLE 15 was not supported, we would like to have support for it.

Addtional Fixes:
 - ecdsa host keys not yet supported
 - removes deprecated option UsePrivilegeSeparation see: https://www.openssh.com/txt/release-7.5

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
